### PR TITLE
Added: Option to exclude app-specific caches from backups.

### DIFF
--- a/onandroid
+++ b/onandroid
@@ -1776,11 +1776,11 @@ if $bb [ "$data_fs" != "" -a "`$bb echo $adv | $bb grep 'd'`" != "" ]; then
 		data_excludes="$data_excludes --exclude=data/data/*/cache/*"
 		data_excludes_dedupe="$data_excludes_dedupe ./data/*/cache/*"
 
-    # Firefox stores its cache within the profile directory.
+		# Firefox stores its cache within the profile directory.
 		data_excludes="$data_excludes --exclude=data/data/org.mozilla.firefox/files/mozilla/*/Cache/*"
 		data_excludes_dedupe="$data_excludes_dedupe ./data/org.mozilla.firefox/files/mozilla/*/Cache/*"
 
-    # TuneIn buffers audio in its top-level directory, not in the app cache.
+		# TuneIn buffers audio in its top-level directory, not in the app cache.
 		data_excludes="$data_excludes --exclude=data/data/tunein.player/cache*.buffer"
 		data_excludes_dedupe="$data_excludes_dedupe ./data/tunein.player/cache*.buffer"
 	fi
@@ -2013,7 +2013,7 @@ else
 	done
 	progress_done
 	$bb echo ""
- 	# Verify md5sum (to check if the file is populated)
+	# Verify md5sum (to check if the file is populated)
 	if $bb [ "`$bb ls -A`" != "nandroid.md5" ]; then
 		logmsg "$LANG_VERIFYMD5SUM...\c"
 		while $bb [ `$bb stat -t nandroid.md5 | $bb awk '{print $2}'` == "0" ]; do


### PR DESCRIPTION
I've seen some apps abuse their cache, letting them grow to over 500MB and taking up a ton of unnecessary space in backups.  Also, the Android developer docs state that the contents of the cache can be deleted at any time (http://developer.android.com/guide/topics/data/data-storage.html#filesInternal), so no app should be relying on anything in there, and thus it shouldn't be necessary to include the caches in the backup.

And, some apps use non-standard cache locations.  While it would be cumbersome to special-case exclusions for many such apps, its worthwhile to do so for a few of the biggest consumers -- for my devices / usage, that's Firefox and TuneIn.
